### PR TITLE
IAV-2349 Input font style fix

### DIFF
--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -1,6 +1,7 @@
 @import "../../sass/dependencies/all";
 
 .input {
+  font: inherit;
   margin: 0;
 }
 


### PR DESCRIPTION
Make input elements inherit font styles (to avoid styling them with browser default styles).

There are two PRs about this change:
- IAV repo: https://github.com/druidfi/aava-iav/pull/223
- Rect component repo: https://github.com/LaakarikeskusAava/react-component-library/pull/15