### PR TITLE
Simplify button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aava-react-component-library",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Component library for Lääkärikeskus Aava.",
   "main": "dist/aava-react-component-library.js",
   "scripts": {

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -8,26 +8,17 @@ export function Button(props) {
   const { className, modifierClass, ...childProps } = props;
   const classes = Classnames('button', className, modifierClass);
 
-  let buttonMarkup = (
-    <button className={classes} {...childProps} />
-  );
-
   // Use <a> element instead of button if button is a link.
   if (typeof childProps.to !== 'undefined') {
-    buttonMarkup = (
-      <Link className={classes} {...childProps}>
-        {props.children}
-      </Link>
-    );
+    return <Link className={classes} {...childProps} />;
   }
 
-  return buttonMarkup;
+  return <button className={classes} {...childProps} />;
 }
 
 Button.propTypes = {
   className: PropTypes.string,
   modifierClass: PropTypes.string,
-  children: PropTypes.string
 };
 
 export default Button;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -9,7 +9,10 @@ export function Button(props) {
   const classes = Classnames('button', className, modifierClass);
 
   // Use <a> element instead of button if button is a link.
-  if (typeof childProps.to !== 'undefined') {
+  if (typeof childProps.to !== 'undefined' && typeof childProps.children !== 'undefined') {
+    // @todo Remove override after https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/310
+    //   has been fixed.
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
     return <Link className={classes} {...childProps} />;
   }
 
@@ -18,7 +21,7 @@ export function Button(props) {
 
 Button.propTypes = {
   className: PropTypes.string,
-  modifierClass: PropTypes.string,
+  modifierClass: PropTypes.string
 };
 
 export default Button;


### PR DESCRIPTION
Currently, the button is too opinionated about children prop since it assumes it is always a string even though technically it supports any kind of node. Remove any assumptions about props passed and simply pass the props for the Link component.